### PR TITLE
Enable to use @import in required scss

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ When you compile your app, just pass `-t sassify` to browserify:
 $ browserify -t sassify entry.js > bundle.js
 ```
 
+## Imports
+
+SASS allows one to `@import` other SASS files. This module synchronously imports those dependencies at the time of the bundling. It looks for the imported files in both the directory of the parent file and the folder where the module itself lives, so it should work so long as the paths in the `@import` commands are correct relative to the importing file, as usual. It is not currently tested for recursive importing.
 
 # Install
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@
 
 var sass = require("node-sass");
 var through = require("through");
+var path = require("path");
 
 module.exports = function (fileName) {
     if (!/(\.scss|\.css)$/i.test(fileName)) {
@@ -9,13 +10,17 @@ module.exports = function (fileName) {
     }
 
     var inputString = "";
+    var includePaths = [path.dirname(fileName), __dirname];
 
     return through(
         function (chunk) {
             inputString += chunk;
         },
         function () {
-            var css = sass.renderSync(inputString);
+            var css = sass.renderSync({
+              data: inputString,
+              includePaths: includePaths
+            });
             css = css
                 .replace(/\'/g, "\\\'")
                 .replace(/\"/g, "\\\"")

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
   "author": "David Guttman",
   "license": "BSD-2-Clause",
   "dependencies": {
-    "cssify": "0.1.0",
-    "node-sass": "~0.4.4",
-    "through": "~2.3.4"
+    "cssify": "^0.5.0",
+    "node-sass": "^0.8.4",
+    "through": "^2.3.4"
   },
   "devDependencies": {},
   "bugs": {


### PR DESCRIPTION
So we can use something like

```
@import 'config';

.style {
  color: $textColor;
}
```

Import path is relative to the required scss file or the project root.

Btw. I updated the dependency versions, because they were pretty outdated and @inlcude seemed to not work with node-sass 0.4.4.
