### PR TITLE
Let globalOptions be undefined

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21,7 +21,7 @@ module.exports = function (fileName, globalOptions) {
 
             // new copy of globalOptions for each file
             options = extend({}, globalOptions || {});
-            options.includePaths = extend([], globalOptions.includePaths || []);
+            options.includePaths = extend([], (globalOptions ? globalOptions.includePaths : {}) || []);
 
             options.data = inputString;
             options.includePaths.unshift(path.dirname(fileName));


### PR DESCRIPTION
If globalOptions is undefined, referencing something on it throws an error. This lets the globalOptions be undefined, as it will only reference the includePaths if it is defined.
