### PR TITLE
Fix blocking behaviour in some configurations

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -41,7 +41,6 @@ module.exports = function (fileName, globalOptions) {
             try {
                 sass.render(options);
             } catch (error) {
-                console.log('error', error);
                 self.emit('error', (error instanceof Error) ? error : new Error(error));
                 done();
             }


### PR DESCRIPTION
The implicit callback in the buffering function made browserify hang in some configurations (I noticed because it happened with a project I'm working on right now).
When I made the callbacks explicit the problem went away.
I also changed the name of the in-memory buffer to 'buffer' cause I thought the name 'inputString' was a bit meh.
