### PR TITLE
Update to latest node-sass version

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -24,23 +24,24 @@ module.exports = tools.makeStringTransform('sassify', {
     options.outFile = opts.file;
     options.sourceMapEmbed = true;
     options.sourceMapContents = true;
-    options.success = function (css) {
+    
+    var callback = function (error,css) {
+        if(error) {
+          return done(error);
+        }
         var exp;
         if (inject) {
         	exp = "require('" + path.basename(path.dirname(__dirname)) + "').byUrl('" + (function() {
-        		var b64 = (new Buffer(css.css)).toString('base64');
+            var b64 = css.css.toString('base64');
         		return 'data:text/css;base64,' + b64;
         	})() + "');";
         } else {
-        	exp = JSON.stringify(css.css);
+          exp = JSON.stringify(css.css.toString());
         }
         var out = "module.exports = " + exp + ";";
                 
         done(null, out);
     };
-    options.error = function(error) {
-        done(error);
-    }
 
-    sass.render(options);
+    sass.render(options, callback);
 });

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "browserify-transform-tools": "^1.3.3",
     "cssify": "^0.7.0",
-    "node-sass": "^2.0.1"
+    "node-sass": "^3.1.2"
   },
   "devDependencies": {
     "browserify": "^9.0.3",


### PR DESCRIPTION
Hi thanks for the library! Just updating to the latest node-sass version here. The success and error keys no longer exist, so just had to change that. [https://github.com/sass/node-sass#render-callback--v300](https://github.com/sass/node-sass#render-callback--v300)