### PR TITLE
added config parameter for disabling the base64Encoding

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -24,22 +24,29 @@ module.exports = tools.makeStringTransform('sassify', {
     options.outFile = opts.file;
     options.sourceMapEmbed = true;
     options.sourceMapContents = true;
-    
+    options.base64Encode = opts.config.base64Encode !== undefined  ? opts.config['base64Encode'] : true;
+
     var callback = function (error,css) {
         if(error) {
           return done(error);
         }
         var exp;
         if (inject) {
-        	exp = "require('" + path.basename(path.dirname(__dirname)) + "').byUrl('" + (function() {
-            var b64 = css.css.toString('base64');
-        		return 'data:text/css;base64,' + b64;
-        	})() + "');";
+            if(options.base64Encode) {
+                exp = "require('" + path.basename(path.dirname(__dirname)) + "').byUrl('" + (function() {
+                var b64 = css.css.toString('base64');
+                  return 'data:text/css;base64,' + b64;
+                })() + "');";
+            } else {
+                exp = "require('" + path.basename(path.dirname(__dirname)) + "')('" + (function() {
+                        return css.css.toString().replace(/'/g, "\\'");
+                    })() + "');";
+            }
         } else {
           exp = JSON.stringify(css.css.toString());
         }
         var out = "module.exports = " + exp + ";";
-                
+
         done(null, out);
     };
 


### PR DESCRIPTION
I've added a config parameter to remove the base64Encoding during the auto-inject action.

```
       .transform(sassify, {
          'auto-inject': true,
          base64Encode: false,
       })
``` 

Embedding styles with base64Encoding create a problem with url resources inside the css that doesn't load anymore.

Eg.

```
.icons-new {
  background-color : red;
  background-image: url("path/to/image.png");
}
```
Show an element with a background color red but the browser don't load the image. Watching the network inspector the call isn't done.

 