### PR TITLE
added configuration on sourceMap generation and bugfix on plain text …

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,36 @@ When you compile your app, just pass `-t sassify` to browserify:
 ```
 $ browserify -t sassify entry.js > bundle.js
 ```
+### Gulp task example 
+...or you can do it using a gulp task.
+
+```javascript
+var gulp = require('gulp');
+var browserify = require('browserify');
+var sassify = require('sassify');
+var source = require('vinyl-source-stream');
+
+gulp.task('build', function(done) {
+  var result = browserify({})
+      .transform(sassify, {
+        'auto-inject': true, // Inject css directly in the code
+        base64Encode: false, // Use base64 to inject css
+        sourceMap: false // Add source map to the code
+      });
+
+  result.add('./entry.js');
+  result.bundle()
+      .pipe(source('output.js'))
+      .pipe(gulp.dest('./'))
+      .on('end', function(err) {
+        if (err) {
+          done(err);
+        } else {
+          done();
+        }
+      });
+});
+```
 
 ## Imports
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,38 +12,39 @@ module.exports = tools.makeStringTransform('sassify', {
     var inject = (typeof opts.config !== 'undefined' && typeof opts.config['auto-inject'] !== 'undefined') ? opts.config['auto-inject'] : false;
     var file = opts.file;
 
-    var options = extend({}, opts.config || {});
+    var options = extend({
+        sourceComments : false,
+        sourceMap : true,
+        sourceMapEmbed : true,
+        sourceMapContents : true,
+        base64Encode : true
+    }, opts.config || {});
+
     options.includePaths = extend([], (opts.config ? opts.config.includePaths : []) || []);
     options.includePaths.unshift(path.dirname(opts.file));
     options.indentedSyntax = /\.sass$/i.test(opts.file);
-
     options.file = file;
     options.data = content;
-    options.sourceComments = false;
-    options.sourceMap = true;
     options.outFile = opts.file;
-    options.sourceMapEmbed = true;
-    options.sourceMapContents = true;
-    options.base64Encode = opts.config.base64Encode !== undefined  ? opts.config['base64Encode'] : true;
 
     var callback = function (error,css) {
         if(error) {
-          return done(error);
+            return done(error);
         }
         var exp;
         if (inject) {
             if(options.base64Encode) {
                 exp = "require('" + path.basename(path.dirname(__dirname)) + "').byUrl('" + (function() {
-                var b64 = css.css.toString('base64');
-                  return 'data:text/css;base64,' + b64;
-                })() + "');";
+                        var b64 = css.css.toString('base64');
+                        return 'data:text/css;base64,' + b64;
+                    })() + "');";
             } else {
                 exp = "require('" + path.basename(path.dirname(__dirname)) + "')('" + (function() {
-                        return css.css.toString().replace(/'/g, "\\'");
+                        return css.css.toString().replace(/'/gm, "\\'").replace(/\n/gm, ' ');
                     })() + "');";
             }
         } else {
-          exp = JSON.stringify(css.css.toString());
+            exp = JSON.stringify(css.css.toString());
         }
         var out = "module.exports = " + exp + ";";
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sassify",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Browserify middleware for adding required styles to the page.",
   "main": "index.js",
   "scripts": {
@@ -17,7 +17,9 @@
     "middleware"
   ],
   "browser": "./lib/sassify-browser.js",
-  "author": "David Guttman",
+  "author": {
+    "name": "David Guttman"
+  },
   "contributors": [
     {
       "name": "Adriaan Callaerts",
@@ -47,6 +49,11 @@
     {
       "name": "Igor Ovsyannikov",
       "url": "https://github.com/ggarek"
+    },
+    {
+      "name": "Davide Fiorello",
+      "email": "davide@codeflyer.com",
+      "url": "https://github.com/codeflyer"
     }
   ],
   "license": "BSD-2-Clause",


### PR DESCRIPTION
…include mode, added sample for gulp task.

The text plain mode failed because my first implementation didn't remove the new lines and the transform throw an error (strings couldn't exists in multiple lines). In my chain there was an uglify after the sassify  transform that solved automatically the problem and I had not noticed that without uglify the transformation will fail, sorry :(

I've changed the config option loading for permit the configuration of the source map.

I've added an example of using with gulp in the README.

