### PR TITLE
Correctly escape everything including \u \f \e

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -53,9 +53,7 @@ module.exports = tools.makeStringTransform('sassify', {
                         return 'data:text/css;base64,' + b64;
                     })() + "');";
             } else {
-                exp = "require('" + path.basename(path.dirname(__dirname)) + "')('" + (function() {
-                        return css.css.toString().replace(/'/gm, "\\'").replace(/\n/gm, ' ');
-                    })() + "');";
+                exp = "require('" + path.basename(path.dirname(__dirname)) + "')(" + JSON.stringify(css.css.toString()) + ");";
             }
         } else {
             exp = JSON.stringify(css.css.toString());


### PR DESCRIPTION
Escape characters like \u (unicode) and \f (font-awesome) were not correctly handled by sassify.

fixes #45 